### PR TITLE
Single entity management

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,139 +30,32 @@ yarn add @euk-labs/fetchx axios mobx
 
 ### HttpService
 
-```tsx
-import { HttpService } from '@euk-labs/fetchx';
-
-const httpService = new HttpService({ baseURL: 'http://localhost:3030/api' });
-
-httpService.setHeader('authorization', 'Bearer token-123');
-
-httpService.client.get('/users');
-httpService.client.post('/users', { name: 'John Doe' });
-```
+The HttpService is a class that will work as a wrapper for axios. It will handle all the requests and provide helpers to make your life easier.
 
 ### Repository
 
-```tsx
-import { Repositor } from '@euk-labs/fetchx';
-
-interface User {
-  name: string;
-  email: string;
-}
-
-interface UserResponse {
-  user: User;
-}
-
-interface UsersResponse {
-  users: User;
-}
-
-// Initializing users repository
-const usersRepository = new Repository(httpService, { path: "/users" });
-
-// Creating entities
-const createdEntity = await usersRepository.create<User, UserResponse>({
-  name: 'John Doe',
-  email: 'john.doe@bestcompany.com',
-});
-
-// Reading entities
-const entities = await usersRepository.read<UsersResponse>();
-const entitiesWithParams = await usersRepository.read<UsersResponse>({
-	name: "John",
-});
-const entityById = await usersRepository.read<UserResponse>("1");
-
-// Updating entities
-const updatedEntityWithPatch = await usersRepository.patch<Partial<User>, UserResponse>("1", {
-	name: "John Doe Updated With Patch",
-});
-let updatedEntityWithPut = await usersRepository.put<User, UserResponse>('1', {
-	name: 'John Doe Updated With Put',
-	email:
-});
-
-// Deleting entity
-await repository.delete('1');
-```
+Repositories will abstract the CRUD operations of your entities. No state is stored in the repository, it only provides methods to fetch, create, update and delete entities.
 
 ### ListStore
 
-```tsx
-import { ListStore } from '@euk-labs/fetchx';
+ListStores are a set of states and actions built with MobX to handle a list of entities with resources like pagination, filters and inifinite scroll strategies.
+They need a repository to work and know how to fetch the data.
 
-const usersListStore = new ListStore(usersRepository, {
-  limit: 10,
-  limitField: 'limit',
-});
-
-// Here we update the state os usersListStore with fresh data
-await usersListStore.fetch();
-
-// Maybe you have only 10 users and want to show more to user
-usersListStore.setPage(2);
-await usersListStore.fetch();
-
-// Want infinite scroll?
-const usersListStore = new ListStore(usersRepository, {
-  limit: 10,
-  limitField: 'limit',
-  infiniteScroll: true,
-});
-
-await usersListStore.fetch();
-usersListStore.setPage(2);
-await usersListStore.fetch();
-
-console.log(usersListStore.list.length); // It will be more than 10, because it increments the list on page change
-```
+Please read the MobX documentation to know more about the different ways to make your components reactive.
 
 ### useList
 
-```tsx
-import * as React from 'react';
-import { HttpService, Repository, useList } from '@euk-labs/fetchx';
-import { observer } from 'mobx-react-lite';
+A hook to use the ListStore in your components. It will return the current state of the ListStore and the actions to interact with it.
+Like ListStore, it needs a repository to work.
 
-interface User {
-  id: string;
-  name: string;
-  email: string;
-}
+### EntityStore
 
-const httpService = new HttpService({
-  baseURL: 'http://localhost:3030/api',
-});
-const usersRepository = new Repository(httpService, { path: '/users' });
+In contrast with the ListStore, EntityStores can only handle a single entity. It can be used to fetch the entity by an identifier, update the loaded entity and delete it.
 
-function UsersPage() {
-  const usersList = useList(usersRepository);
+### useEntity
 
-  React.useEffect(() => {
-    usersList.fetch();
-  }, []);
-
-  if (usersList.loading) {
-    return <div>Loading...</div>;
-  }
-
-  if (usersList.list.length === 0) {
-    return <div>No users</div>;
-  }
-
-  return (
-    <div data-testid="usersList">
-      {(usersList.list as User[]).map((user) => (
-        <p key={user.id}>- {user.name}</p>
-      ))}
-    </div>
-  );
-}
-
-export default observer(UsersPage);
-```
+A hook to use the EntityStore in your components. It will return the current state of the EntityStore and the actions to interact with it.
+Like EntityStore, it needs a repository to work.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -28,31 +28,31 @@ yarn add @euk-labs/fetchx axios mobx
 
 ## Usage
 
-### HttpService
+### `HttpService`
 
 The HttpService is a class that will work as a wrapper for axios. It will handle all the requests and provide helpers to make your life easier.
 
-### Repository
+### `Repository`
 
 Repositories will abstract the CRUD operations of your entities. No state is stored in the repository, it only provides methods to fetch, create, update and delete entities.
 
-### ListStore
+### `ListStore`
 
 ListStores are a set of states and actions built with MobX to handle a list of entities with resources like pagination, filters and inifinite scroll strategies.
 They need a repository to work and know how to fetch the data.
 
 Please read the MobX documentation to know more about the different ways to make your components reactive.
 
-### useList
+### `useList`
 
 A hook to use the ListStore in your components. It will return the current state of the ListStore and the actions to interact with it.
 Like ListStore, it needs a repository to work.
 
-### EntityStore
+### `EntityStore`
 
 In contrast with the ListStore, EntityStores can only handle a single entity. It can be used to fetch the entity by an identifier, update the loaded entity and delete it.
 
-### useEntity
+### `useEntity`
 
 A hook to use the EntityStore in your components. It will return the current state of the EntityStore and the actions to interact with it.
 Like EntityStore, it needs a repository to work.

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "rimraf": "^3.0.2",
     "rollup": "^2.60.1",
     "rollup-plugin-dts": "^4.0.1",
-    "rollup-plugin-peer-deps-external": "^2.2.4",
+    "rollup-plugin-exclude-dependencies-from-bundle": "^1.1.21",
     "rollup-plugin-postcss": "^4.0.2",
     "rollup-plugin-terser": "^7.0.2",
     "ts-jest": "^27.0.7",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -2,7 +2,6 @@ import resolve from '@rollup/plugin-node-resolve';
 import commonjs from '@rollup/plugin-commonjs';
 import typescript from '@rollup/plugin-typescript';
 import { terser } from 'rollup-plugin-terser';
-// import external from 'rollup-plugin-peer-deps-external';
 import postcss from 'rollup-plugin-postcss';
 import dts from 'rollup-plugin-dts';
 import excludeDependenciesFromBundle from 'rollup-plugin-exclude-dependencies-from-bundle';

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,41 +1,45 @@
-import resolve from "@rollup/plugin-node-resolve";
-import commonjs from "@rollup/plugin-commonjs";
-import typescript from "@rollup/plugin-typescript";
-import { terser } from "rollup-plugin-terser";
-import external from "rollup-plugin-peer-deps-external";
-import postcss from "rollup-plugin-postcss";
-import dts from "rollup-plugin-dts";
+import resolve from '@rollup/plugin-node-resolve';
+import commonjs from '@rollup/plugin-commonjs';
+import typescript from '@rollup/plugin-typescript';
+import { terser } from 'rollup-plugin-terser';
+// import external from 'rollup-plugin-peer-deps-external';
+import postcss from 'rollup-plugin-postcss';
+import dts from 'rollup-plugin-dts';
+import excludeDependenciesFromBundle from 'rollup-plugin-exclude-dependencies-from-bundle';
 
-const packageJson = require("./package.json");
+const packageJson = require('./package.json');
 
 export default [
   {
-    input: "src/index.ts",
+    input: 'src/index.ts',
     output: [
       {
         file: packageJson.main,
-        format: "cjs",
+        format: 'cjs',
         sourcemap: true,
-        name: "react-lib",
+        name: 'react-lib',
       },
       {
         file: packageJson.module,
-        format: "esm",
+        format: 'esm',
         sourcemap: true,
       },
     ],
     plugins: [
-      external(),
+      excludeDependenciesFromBundle({
+        dependencies: true,
+        peerDependencies: true,
+      }),
       resolve(),
       commonjs(),
-      typescript({ tsconfig: "./tsconfig.build.json" }),
+      typescript({ tsconfig: './tsconfig.build.json' }),
       postcss(),
       terser(),
     ],
   },
   {
-    input: "lib/esm/types/index.d.ts",
-    output: [{ file: "lib/index.d.ts", format: "esm" }],
+    input: 'lib/esm/types/index.d.ts',
+    output: [{ file: 'lib/index.d.ts', format: 'esm' }],
     external: [/\.css$/],
     plugins: [dts()],
   },

--- a/src/EntityStore.ts
+++ b/src/EntityStore.ts
@@ -1,0 +1,78 @@
+import 'reflect-metadata';
+import { makeAutoObservable } from 'mobx';
+import Repository from './Repository';
+import { injectable } from 'inversify';
+import { Identifier } from './types';
+
+@injectable()
+export default class EntityStore {
+  constructor(private repository: Repository) {
+    makeAutoObservable<EntityStore, 'repository'>(
+      this,
+      { repository: false },
+      { autoBind: true }
+    );
+  }
+
+  loading = false;
+  data: unknown | null = null;
+  identifier: Identifier | null = null;
+
+  setLoading(loading: boolean) {
+    this.loading = loading;
+  }
+
+  setData(data: unknown | null) {
+    this.data = data;
+  }
+
+  setIdentifier(identifier: Identifier) {
+    this.identifier = identifier;
+  }
+
+  async fetch() {
+    if (!this.identifier) {
+      return console.warn("Can't fetch without an identifier");
+    }
+
+    this.setLoading(true);
+
+    try {
+      const response = await this.repository.read(this.identifier);
+      this.setData(response.data);
+    } finally {
+      this.setLoading(false);
+    }
+  }
+
+  async update(data: unknown) {
+    if (!this.identifier) {
+      return console.warn("Can't update without an identifier");
+    }
+
+    this.setLoading(true);
+
+    try {
+      const response = await this.repository.patch(this.identifier, data);
+      this.setData(response.data);
+      return response.data;
+    } finally {
+      this.setLoading(false);
+    }
+  }
+
+  async delete() {
+    if (!this.identifier) {
+      return console.warn("Can't delete without an identifier");
+    }
+
+    this.setLoading(true);
+
+    try {
+      await this.repository.delete(this.identifier);
+      this.setData(null);
+    } finally {
+      this.setLoading(false);
+    }
+  }
+}

--- a/src/ListStore.ts
+++ b/src/ListStore.ts
@@ -2,13 +2,7 @@ import 'reflect-metadata';
 import { makeAutoObservable } from 'mobx';
 import Repository from './Repository';
 import { injectable } from 'inversify';
-
-export interface ListStoreOptions {
-  infiniteScroll?: boolean;
-  limitField: string;
-  limit: number;
-  resultsField?: string;
-}
+import { ListStoreOptions } from './types';
 
 @injectable()
 export default class ListStore {

--- a/src/Repository.ts
+++ b/src/Repository.ts
@@ -2,8 +2,8 @@ import 'reflect-metadata';
 import { AxiosResponse } from 'axios';
 import HttpService from './HttpService';
 import { injectable } from 'inversify';
+import { Identifier } from './types';
 
-type Identifier = string | number;
 interface RepositoryOptions {
   /**
    * The base url of the repository.
@@ -59,14 +59,14 @@ export default class Repository {
     >(`${this._options.path}/${id}`, data);
   }
 
-  put<Data, Response>(id: string, data: unknown) {
+  put<Data, Response>(id: Identifier, data: unknown) {
     return this._apiService.client.put<Response, AxiosResponse<Response, Data>>(
       `${this._options.path}/${id}`,
       data
     );
   }
 
-  delete<T>(id: string) {
+  delete<T>(id: Identifier) {
     return this._apiService.client.delete<T>(`${this._options.path}/${id}`);
   }
 }

--- a/src/Repository.ts
+++ b/src/Repository.ts
@@ -2,15 +2,7 @@ import 'reflect-metadata';
 import { AxiosResponse } from 'axios';
 import HttpService from './HttpService';
 import { injectable } from 'inversify';
-import { Identifier } from './types';
-
-interface RepositoryOptions {
-  /**
-   * The base url of the repository.
-   * @link https://shoulders.dev/docs/api/repository#options
-   */
-  path: string;
-}
+import { Identifier, RepositoryOptions } from './types';
 
 @injectable()
 export default class Repository {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,7 @@
 export { default as HttpService } from './HttpService';
-export { default as ListStore } from './ListStore';
 export { default as Repository } from './Repository';
+export { default as ListStore } from './ListStore';
+export { default as EntityStore } from './EntityStore';
 export { default as useList } from './useList';
+export { default as useEntity } from './useEntity';
+export * from './types';

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,1 @@
+export type Identifier = string | number;

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,1 +1,12 @@
 export type Identifier = string | number;
+
+export interface RepositoryOptions {
+  path: string;
+}
+
+export interface ListStoreOptions {
+  infiniteScroll?: boolean;
+  limitField: string;
+  limit: number;
+  resultsField?: string;
+}

--- a/src/useEntity.ts
+++ b/src/useEntity.ts
@@ -1,0 +1,16 @@
+import { useEffect, useMemo } from 'react';
+import { Identifier } from './types';
+import Repository from './Repository';
+import EntityStore from './EntityStore';
+
+export default function useEntity(repository: Repository, id?: Identifier) {
+  const dataStore = useMemo(() => new EntityStore(repository), []);
+
+  useEffect(() => {
+    if (typeof id === 'string' || typeof id === 'number') {
+      dataStore.setIdentifier(id);
+    }
+  }, [id]);
+
+  return dataStore;
+}

--- a/src/useList.ts
+++ b/src/useList.ts
@@ -1,5 +1,6 @@
 import { useMemo } from 'react';
-import ListStore, { ListStoreOptions } from './ListStore';
+import { ListStoreOptions } from './types';
+import ListStore from './ListStore';
 import Repository from './Repository';
 
 export default function useList(

--- a/tests/EntityStore.spec.ts
+++ b/tests/EntityStore.spec.ts
@@ -1,4 +1,4 @@
-import { EntityStore, ListStore } from '../src';
+import { EntityStore } from '../src';
 import mockServer from './fixtures/server';
 import usersRepository from './fixtures/usersRepository';
 import faker from 'faker';

--- a/tests/EntityStore.spec.ts
+++ b/tests/EntityStore.spec.ts
@@ -1,0 +1,122 @@
+import { EntityStore, ListStore } from '../src';
+import mockServer from './fixtures/server';
+import usersRepository from './fixtures/usersRepository';
+import faker from 'faker';
+import { waitFor } from '@testing-library/dom';
+
+const INITIAL_USERS = 1;
+const server = mockServer();
+
+describe('EntityStore', () => {
+  let consoleSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    if (consoleSpy) {
+      consoleSpy.mockReset();
+    }
+  });
+
+  beforeAll(() => {
+    for (let index = 0; index < INITIAL_USERS; index++) {
+      (server as any).create('user', {
+        name: faker.name.findName(),
+        email: faker.internet.email(),
+      });
+    }
+  });
+
+  afterAll(() => {
+    server.shutdown();
+  });
+
+  it('should be created', () => {
+    const userStore = new EntityStore(usersRepository);
+
+    expect(userStore).toBeTruthy();
+  });
+
+  it('should warn when fetching without identifier', () => {
+    consoleSpy = jest.spyOn(console, 'warn').mockImplementation();
+
+    const userStore = new EntityStore(usersRepository);
+
+    userStore.fetch();
+
+    expect(consoleSpy).toHaveBeenCalled();
+  });
+
+  it('should fetch data and update store', async () => {
+    const userStore = new EntityStore(usersRepository);
+
+    userStore.setIdentifier('1');
+    userStore.fetch();
+
+    expect(userStore.loading).toBeTruthy();
+
+    await waitFor(() => {
+      expect(userStore.data).toBeTruthy();
+    });
+  });
+
+  it('should warn when updating without identifier', () => {
+    consoleSpy = jest.spyOn(console, 'warn').mockImplementation();
+
+    const userStore = new EntityStore(usersRepository);
+
+    userStore.update({ name: 'John' });
+
+    expect(consoleSpy).toHaveBeenCalled();
+  });
+
+  it('should update entity mutating the store', async () => {
+    const userStore = new EntityStore(usersRepository);
+
+    userStore.setIdentifier('1');
+    userStore.fetch();
+
+    await waitFor(() => {
+      expect(userStore.data).toBeTruthy();
+    });
+
+    const user = (userStore.data as any).user;
+    user.name = 'John Doe';
+
+    userStore.update(user);
+
+    expect(userStore.loading).toBeTruthy();
+
+    await waitFor(() => {
+      expect(userStore.data).toBeTruthy();
+      expect((userStore.data as any).user).toEqual(user);
+    });
+  });
+
+  it('should warn when deleting without identifier', () => {
+    consoleSpy = jest.spyOn(console, 'warn').mockImplementation();
+
+    const userStore = new EntityStore(usersRepository);
+
+    userStore.delete();
+
+    expect(consoleSpy).toHaveBeenCalled();
+  });
+
+  it('should reset store when deleting entity', async () => {
+    const userStore = new EntityStore(usersRepository);
+
+    userStore.setIdentifier('1');
+    userStore.fetch();
+
+    await waitFor(() => {
+      expect(userStore.data).toBeTruthy();
+    });
+
+    userStore.delete();
+
+    expect(userStore.loading).toBeTruthy();
+
+    await waitFor(() => {
+      expect(userStore.data).toBeFalsy();
+    });
+  });
+});

--- a/tests/HttpService.spec.ts
+++ b/tests/HttpService.spec.ts
@@ -1,117 +1,117 @@
-import HttpService from "../src/HttpService";
-import mockServer from "./fixtures/server";
+import HttpService from '../src/HttpService';
+import mockServer from './fixtures/server';
 
 const server = mockServer();
 
-describe("HttpService", () => {
+describe('HttpService', () => {
   afterAll(() => {
     server.shutdown();
   });
 
-  it("should be created", () => {
-    const httpService = new HttpService({ baseURL: "/api" });
+  it('should be created', () => {
+    const httpService = new HttpService({ baseURL: '/api' });
 
     expect(httpService).toBeTruthy();
   });
 
-  it("should have the correct baseURL", () => {
-    const httpService = new HttpService({ baseURL: "/api" });
+  it('should have the correct baseURL', () => {
+    const httpService = new HttpService({ baseURL: '/api' });
 
-    expect(httpService.client.defaults.baseURL).toBe("/api");
+    expect(httpService.client.defaults.baseURL).toBe('/api');
   });
 
-  it("should have the correct default headers", () => {
-    const httpService = new HttpService({ baseURL: "/api" });
+  it('should have the correct default headers', () => {
+    const httpService = new HttpService({ baseURL: '/api' });
 
     expect(httpService.client.defaults.headers.common).toEqual({
-      Accept: "application/json, text/plain, */*",
+      Accept: 'application/json, text/plain, */*',
     });
   });
 
-  it("should make a successfull GET request", async () => {
-    const httpService = new HttpService({ baseURL: "/api" });
-    const response = await httpService.client.get("/users");
+  it('should make a successfull GET request', async () => {
+    const httpService = new HttpService({ baseURL: '/api' });
+    const response = await httpService.client.get('/users');
 
     expect(response.status).toBe(200);
   });
 
-  it("should throw an error when the request fails", async () => {
-    const httpService = new HttpService({ baseURL: "/api" });
+  it('should throw an error when the request fails', async () => {
+    const httpService = new HttpService({ baseURL: '/api' });
 
-    await expect(httpService.client.get("/does-not-exist")).rejects.toThrow();
+    await expect(httpService.client.get('/does-not-exist')).rejects.toThrow();
   });
 
-  it("should change headers with helper method", () => {
-    const httpService = new HttpService({ baseURL: "/api" });
-    const fakeToken = "fake-token";
+  it('should change headers with helper method', () => {
+    const httpService = new HttpService({ baseURL: '/api' });
+    const fakeToken = 'fake-token';
 
-    httpService.setHeader("authorization", fakeToken);
+    httpService.setHeader('authorization', fakeToken);
 
     expect(httpService.client.defaults.headers.common).toHaveProperty(
-      "authorization",
+      'authorization',
       fakeToken
     );
   });
 
-  it("should set request interceptor with helper method", async () => {
-    const httpService = new HttpService({ baseURL: "/api" });
-    const fakeToken = "fake-token";
+  it('should set request interceptor with helper method', async () => {
+    const httpService = new HttpService({ baseURL: '/api' });
+    const fakeToken = 'fake-token';
 
-    httpService.setRequestInterceptor("token-injector", (config) => {
+    httpService.setRequestInterceptor('token-injector', (config) => {
       if (config.headers) config.headers.authorization = fakeToken;
 
       return config;
     });
 
-    const response = await httpService.client.get("/users");
+    const response = await httpService.client.get('/users');
 
-    expect(response.config.headers).toHaveProperty("authorization", fakeToken);
+    expect(response.config.headers).toHaveProperty('authorization', fakeToken);
   });
 
-  it("should set response interceptor with helper method", async () => {
-    const httpService = new HttpService({ baseURL: "/api" });
+  it('should set response interceptor with helper method', async () => {
+    const httpService = new HttpService({ baseURL: '/api' });
 
-    httpService.setResponseInterceptor("now-injector", (response) => {
+    httpService.setResponseInterceptor('now-injector', (response) => {
       if (response.headers) response.headers.nowDate = new Date().toISOString();
 
       return response;
     });
 
-    const response = await httpService.client.get("/users");
+    const response = await httpService.client.get('/users');
 
-    expect(response.headers).toHaveProperty("nowDate");
+    expect(response.headers).toHaveProperty('nowDate');
   });
 
-  it("should eject request interceptors with helper method", async () => {
-    const httpService = new HttpService({ baseURL: "/api" });
-    const fakeToken = "fake-token";
+  it('should eject request interceptors with helper method', async () => {
+    const httpService = new HttpService({ baseURL: '/api' });
+    const fakeToken = 'fake-token';
 
-    httpService.setRequestInterceptor("token-injector", (config) => {
+    httpService.setRequestInterceptor('token-injector', (config) => {
       if (config.headers) config.headers.authorization = fakeToken;
 
       return config;
     });
 
-    httpService.ejectInterceptor("token-injector", "request");
+    httpService.ejectInterceptor('token-injector', 'request');
 
-    const response = await httpService.client.get("/users");
+    const response = await httpService.client.get('/users');
 
-    expect(response.config.headers).not.toHaveProperty("authorization");
+    expect(response.config.headers).not.toHaveProperty('authorization');
   });
 
-  it("should eject response interceptors with helper method", async () => {
-    const httpService = new HttpService({ baseURL: "/api" });
-    httpService.setResponseInterceptor("now-injector", (response) => {
+  it('should eject response interceptors with helper method', async () => {
+    const httpService = new HttpService({ baseURL: '/api' });
+    httpService.setResponseInterceptor('now-injector', (response) => {
       if (response.headers) response.headers.nowDate = new Date().toISOString();
 
       return response;
     });
-    const response = await httpService.client.get("/users");
-    expect(response.headers).toHaveProperty("nowDate");
+    const response = await httpService.client.get('/users');
+    expect(response.headers).toHaveProperty('nowDate');
 
-    httpService.ejectInterceptor("now-injector", "response");
+    httpService.ejectInterceptor('now-injector', 'response');
 
-    const newResponse = await httpService.client.get("/users");
-    expect(newResponse.config.headers).not.toHaveProperty("authorization");
+    const newResponse = await httpService.client.get('/users');
+    expect(newResponse.config.headers).not.toHaveProperty('authorization');
   });
 });

--- a/tests/fixtures/UserPage.tsx
+++ b/tests/fixtures/UserPage.tsx
@@ -1,0 +1,72 @@
+import * as React from 'react';
+import usersRepository from './usersRepository';
+import { observer } from 'mobx-react-lite';
+import faker from 'faker';
+import { useEntity } from '../../src';
+
+interface User {
+  name: string;
+  email: string;
+}
+
+interface UserResponse {
+  user: User;
+}
+
+interface UserPageProps {
+  id?: string;
+  forceFetch?: boolean;
+  forceUpdate?: boolean;
+  forceDelete?: boolean;
+}
+
+function UserPage({ id, forceFetch, forceUpdate, forceDelete }: UserPageProps) {
+  const entity = useEntity(usersRepository, id);
+  const user: User | null = (entity.data as UserResponse)?.user;
+
+  function setRandomName() {
+    entity.update({ name: faker.name.findName() });
+  }
+
+  React.useEffect(() => {
+    if (forceUpdate) {
+      setRandomName();
+    }
+
+    if (forceDelete) {
+      entity.delete();
+    }
+
+    if (forceFetch) {
+      entity.fetch();
+    }
+  }, [forceUpdate, forceFetch]);
+
+  React.useEffect(() => {
+    if (id) {
+      entity.fetch();
+    }
+  }, [id]);
+
+  if (!id) return <div data-testid="user">No identifier provided!</div>;
+
+  if (entity.loading) return <div data-testid="user">Loading...</div>;
+
+  if (!entity.data) return <div data-testid="user">Not found!</div>;
+
+  return (
+    <div data-testid="user">
+      <p data-testid="user-name">Name: {user.name}</p>
+      <p data-testid="user-email">E-mail: {user.email}</p>
+
+      <button data-testid="set-random-name" onClick={setRandomName}>
+        Set random name
+      </button>
+      <button data-testid="delete-user" onClick={entity.delete}>
+        Delete
+      </button>
+    </div>
+  );
+}
+
+export default observer(UserPage);

--- a/tests/useEntity.spec.tsx
+++ b/tests/useEntity.spec.tsx
@@ -1,0 +1,165 @@
+import React from 'react';
+import mockServer from './fixtures/server';
+import faker from 'faker';
+import { getByTestId, render, waitFor } from '@testing-library/react';
+import UserPage from './fixtures/UserPage';
+
+const INITIAL_USERS = 1;
+const server = mockServer();
+
+describe('useEntity', () => {
+  let consoleSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    if (consoleSpy) {
+      consoleSpy.mockRestore();
+    }
+  });
+
+  beforeAll(() => {
+    for (let index = 0; index < INITIAL_USERS; index++) {
+      (server as any).create('user', {
+        name: faker.name.findName(),
+        email: faker.internet.email(),
+      });
+    }
+  });
+
+  afterAll(() => {
+    server.shutdown();
+  });
+
+  it('should be created', () => {
+    const { container } = render(<UserPage />);
+
+    expect(container).toBeTruthy();
+  });
+
+  it('should show no identifier message', async () => {
+    const { container } = render(<UserPage />);
+    const userDisplay = getByTestId(container, 'user');
+
+    expect(userDisplay.textContent).toContain('No identifier provided!');
+  });
+
+  it('should warn about fetching without identifier', () => {
+    consoleSpy = jest.spyOn(console, 'warn').mockImplementation();
+
+    const { container } = render(<UserPage forceFetch />);
+    const userDisplay = getByTestId(container, 'user');
+
+    expect(userDisplay.textContent).toContain('No identifier provided!');
+    expect(console.warn).toHaveBeenCalled();
+  });
+
+  it('should show user data', async () => {
+    const { container } = render(<UserPage id={'1'} />);
+    const userDisplay = getByTestId(container, 'user');
+
+    await waitFor(() => {
+      expect(userDisplay.textContent).toContain('Loading...');
+    });
+
+    await waitFor(() => {
+      const userName = getByTestId(container, 'user-name');
+      expect(userName.textContent).toBeDefined();
+    });
+  });
+
+  it('should show that user does not exist', async () => {
+    const { container } = render(<UserPage id={'2'} />);
+    const userDisplay = getByTestId(container, 'user');
+
+    await waitFor(() => {
+      expect(userDisplay.textContent).toContain('Loading...');
+    });
+
+    await waitFor(() => {
+      expect(userDisplay.textContent).toContain('Not found!');
+    });
+  });
+
+  it('should warn on update without identifier', async () => {
+    consoleSpy = jest.spyOn(console, 'warn').mockImplementation();
+
+    const { container } = render(<UserPage forceUpdate />);
+    const userDisplay = getByTestId(container, 'user');
+
+    await waitFor(() => {
+      expect(userDisplay.textContent).toContain('No identifier provided!');
+    });
+
+    await waitFor(() => {
+      expect(console.warn).toHaveBeenCalled();
+    });
+  });
+
+  it("should update user's name", async () => {
+    const { container } = render(<UserPage id={'1'} />);
+    const userDisplay = getByTestId(container, 'user');
+
+    await waitFor(() => {
+      expect(userDisplay.textContent).toContain('Loading...');
+    });
+
+    let oldName = '';
+    await waitFor(() => {
+      const userName = getByTestId(container, 'user-name');
+      expect(userName.textContent).toBeDefined();
+      oldName = userName.textContent || '';
+    });
+
+    const setRandomNameButton = getByTestId(container, 'set-random-name');
+    setRandomNameButton.click();
+
+    await waitFor(() => {
+      expect(userDisplay.textContent).toContain('Loading...');
+    });
+
+    await waitFor(() => {
+      const userName = getByTestId(container, 'user-name');
+      expect(userName.textContent).not.toEqual('');
+      expect(userName.textContent).not.toEqual(oldName);
+    });
+  });
+
+  it('should warn on delete without identifier', async () => {
+    consoleSpy = jest.spyOn(console, 'warn').mockImplementation();
+
+    const { container } = render(<UserPage forceDelete />);
+    const userDisplay = getByTestId(container, 'user');
+
+    await waitFor(() => {
+      expect(userDisplay.textContent).toContain('No identifier provided!');
+    });
+
+    await waitFor(() => {
+      expect(console.warn).toHaveBeenCalled();
+    });
+  });
+
+  it('should delete user', async () => {
+    const { container } = render(<UserPage id={'1'} />);
+    const userDisplay = getByTestId(container, 'user');
+
+    await waitFor(() => {
+      expect(userDisplay.textContent).toContain('Loading...');
+    });
+
+    await waitFor(() => {
+      const userName = getByTestId(container, 'user-name');
+      expect(userName.textContent).toBeDefined();
+    });
+
+    const deleteButton = getByTestId(container, 'delete-user');
+    deleteButton.click();
+
+    await waitFor(() => {
+      expect(userDisplay.textContent).toContain('Loading...');
+    });
+
+    await waitFor(() => {
+      expect(userDisplay.textContent).toContain('Not found!');
+    });
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,7 +9,6 @@
     "module": "esnext",
     "rootDir": "src",
     "moduleResolution": "node",
-    "baseUrl": "src",
     "sourceMap": true,
     "allowSyntheticDefaultImports": true,
     "esModuleInterop": true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -140,7 +140,7 @@
   dependencies:
     "@babel/types" "^7.16.0"
 
-"@babel/helper-module-imports@^7.12.13", "@babel/helper-module-imports@^7.16.0":
+"@babel/helper-module-imports@^7.10.4", "@babel/helper-module-imports@^7.12.13", "@babel/helper-module-imports@^7.16.0":
   version "7.16.0"
   resolved "https://registry.yarnpkg.com/@babel/helper-module-imports/-/helper-module-imports-7.16.0.tgz#90538e60b672ecf1b448f5f4f5433d37e79a3ec3"
   integrity sha512-kkH7sWzKPq0xt3H1n+ghb4xEMP8k0U7XV3kkB+ZGy69kDk2ySFW1qPi06sjKzFY3t1j6XbJSqr4mF9L7CYVyhg==
@@ -1361,6 +1361,14 @@
   dependencies:
     "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
+
+"@rollup/plugin-babel@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@rollup/plugin-babel/-/plugin-babel-5.3.0.tgz#9cb1c5146ddd6a4968ad96f209c50c62f92f9879"
+  integrity sha512-9uIC8HZOnVLrLHxayq/PTzw+uS25E14KPUBh5ktF+18Mjo5yK0ToMMx6epY0uEgkjwJw0aBW4x2horYXh8juWw==
+  dependencies:
+    "@babel/helper-module-imports" "^7.10.4"
+    "@rollup/pluginutils" "^3.1.0"
 
 "@rollup/plugin-commonjs@^21.0.1":
   version "21.0.1"
@@ -5277,10 +5285,13 @@ rollup-plugin-dts@^4.0.1:
   optionalDependencies:
     "@babel/code-frame" "^7.14.5"
 
-rollup-plugin-peer-deps-external@^2.2.4:
-  version "2.2.4"
-  resolved "https://registry.yarnpkg.com/rollup-plugin-peer-deps-external/-/rollup-plugin-peer-deps-external-2.2.4.tgz#8a420bbfd6dccc30aeb68c9bf57011f2f109570d"
-  integrity sha512-AWdukIM1+k5JDdAqV/Cxd+nejvno2FVLVeZ74NKggm3Q5s9cbbcOgUPGdbxPi4BXu7xGaZ8HG12F+thImYu/0g==
+rollup-plugin-exclude-dependencies-from-bundle@^1.1.21:
+  version "1.1.21"
+  resolved "https://registry.yarnpkg.com/rollup-plugin-exclude-dependencies-from-bundle/-/rollup-plugin-exclude-dependencies-from-bundle-1.1.21.tgz#740e9b9d26bd966d278aaa7d01b1756579218e60"
+  integrity sha512-inzaaqYIKOmVQlJVIEDfTTCUXNUrLPuXqleU+Tb9e5C/56QhoRbZ7GDmPDw6Ea9fPnMXN12Dy10xtRxS+Nw4OQ==
+  dependencies:
+    "@rollup/plugin-babel" "^5.3.0"
+    "@rollup/plugin-node-resolve" "^13.0.6"
 
 rollup-plugin-postcss@^4.0.2:
   version "4.0.2"


### PR DESCRIPTION
Added EntityStore class and useEntity hook that will handle single entity operations like update and delete with observables to use in React components.

### `EntityStore` useful properties
- loading
- data
- fetch()
- update(data)
- delete()

### `useEntity`
```
const entity = useEntity(usersRepository, params.id)

useEffect(() => {
  params.id && entity.fetch()
}, [params.id])

```